### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "require": {
         "jaxon-php/jaxon-core": "~1.0",
         "jaxon-php/jaxon-framework": "~1.0",
-        "symfony/symfony": "2.8.*|3.0.*"
+        "symfony/symfony": "2.8.*|3.1.*"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
I have just installed symfony 3.1.6 and want to install jaxon.

The problem is, jaxon wants older version.
jaxon-php/jaxon-symfony v1.0.2 requires symfony/symfony 2.8.*|3.0.*

-----------------------------
Thank you for jaxon.
I use xajax and smarty several jears and now I will move my application to symfony, and it's great that you have done the work to use xajax with symfony.